### PR TITLE
Add support for Unddit.com

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,6 +23,16 @@
                 <data android:mimeType="text/plain" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".UndditActivity"
+            android:label="@string/unddit_name"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/plain" />
+            </intent-filter>
+        </activity>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/agreenbhm/reveddit/MainActivity.java
+++ b/app/src/main/java/com/agreenbhm/reveddit/MainActivity.java
@@ -40,16 +40,22 @@ public class MainActivity extends AppCompatActivity {
             try {
                 if (path.regionMatches(true, 0, "/r/", 0, 3)) {
                     Intent i = new Intent(Intent.ACTION_VIEW);
-                    String reveddit = "https://reveddit.com/v/" + path.substring(3);
+                    String reveddit = "https://www.reveddit.com/v/" + path.substring(3);
                     i.setData(Uri.parse(reveddit));
                     //Log.d("Reveddit", reveddit);
                     startActivity(i);
-                } else{
+                } else if (path.regionMatches(true, 0, "/user/", 0, 6)) {
+                    Intent i = new Intent(Intent.ACTION_VIEW);
+                    String reveddit = "https://www.reveddit.com/y/" + path.substring(6);
+                    i.setData(Uri.parse(reveddit));
+                    //Log.d("Reveddit", reveddit);
+                    startActivity(i);
+                } else {
                     Context context = getApplicationContext();
                     Toast toast = Toast.makeText(context, "Unsupported URL", Toast.LENGTH_SHORT);
                     toast.show();
                 }
-                //Log.d("Reveddit", path.substring(0, 3));
+                //Log.d("Reveddit", path);
                 //Log.d("Reveddit", sharedText);
             }catch (Exception e) {
                 Log.d("Reveddit", e.getMessage());

--- a/app/src/main/java/com/agreenbhm/reveddit/UndditActivity.java
+++ b/app/src/main/java/com/agreenbhm/reveddit/UndditActivity.java
@@ -1,0 +1,55 @@
+package com.agreenbhm.reveddit;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+import android.util.Log;
+import android.widget.Toast;
+
+public class UndditActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_main);
+        // Get intent, action and MIME type
+        Intent intent = getIntent();
+        String action = intent.getAction();
+        String type = intent.getType();
+
+        if (Intent.ACTION_SEND.equals(action) && type != null) {
+            if ("text/plain".equals(type)) {
+                handleSendText(intent); // Handle text being sent
+            }
+        }
+        finish();
+    }
+
+    void handleSendText(Intent intent) {
+        String sharedText = intent.getStringExtra(Intent.EXTRA_TEXT);
+        if (sharedText != null) {
+            Uri uri = Uri.parse(sharedText);
+            String path = uri.getPath();
+            try {
+                if (path.matches("/(?:r|user)/[^/?]+/comments/\\w.*")) {
+                    Intent i = new Intent(Intent.ACTION_VIEW);
+                    String unddit = "https://www.unddit.com" + path;
+                    i.setData(Uri.parse(unddit));
+                    //Log.d("Reveddit", unddit);
+                    startActivity(i);
+                } else {
+                    Context context = getApplicationContext();
+                    Toast toast = Toast.makeText(context, "Unsupported URL", Toast.LENGTH_SHORT);
+                    toast.show();
+                }
+                //Log.d("Reveddit", path);
+                //Log.d("Reveddit", sharedText);
+            } catch (Exception e) {
+                Log.d("Reveddit", e.getMessage());
+            }
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name">Reveddit</string>
+    <string name="unddit_name">Unddit</string>
 </resources>


### PR DESCRIPTION
This PR adds a new share target labeled `Unddit` (without changing the existing `Reveddit` target) which opens a Reddit thread on https://www.unddit.com/. Unddit is a fork of the (apparently defunct) Removeddit project. Its source code is available at https://github.com/gurnec/removeddit. (Full disclosure: I'm maintaining this website.)

Although Reveddit is (IMO) superior in many ways, Unddit's load times are faster (in some cases much faster), especially on lower-end devices.

It's of course up to you if you think adding Unddit makes sense for your app. If you decide it doesn't, please feel free to cherry-pick only the `Added support for Reveddit user pages` commit if you'd like.